### PR TITLE
Version 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ To develop and test the extension, you need to open the "about:debugging" page i
 Further documentation about developing Firefox extensions can be found [here](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/Your_first_WebExtension).
 
 ## Release Notes
+### Version 2.2
+* **[FIXED]** Opening link in new tab no longer creates additional blank tab
+* **[FIXED]** Created tab always appears next to the original tab
+
 ### Version 2.1
 * **[FIXED]** Outlook now opens in a new tab
 * **[FIXED]** The Outlook selection screen will not load if you have selected "Don't ask again"

--- a/firefox/background.js
+++ b/firefox/background.js
@@ -43,9 +43,19 @@ async function openTab(requestDetails) {
 	var params = await getParameters(requestDetails.url);
 	var base = await getBase();
 	var link = base + params;
-	browser.tabs.create({
-		url:link
-	});
+	let tabInfo = await browser.tabs.get(requestDetails.tabId);
+	
+	// Checks if the link is already in a new tab or if a new tab needs to be created
+	if (tabInfo.url == 'about:blank') {
+		browser.tabs.update(requestDetails.tabId, {
+			url:link
+		});
+	} else {
+		browser.tabs.create({
+			url:link
+		});
+	}
+	
 	saveMessage({'code':'create-handler','msg':[link,params]})
 	return {cancel: true};
 }

--- a/firefox/background.js
+++ b/firefox/background.js
@@ -52,6 +52,7 @@ async function openTab(requestDetails) {
 		});
 	} else {
 		browser.tabs.create({
+			index:tabInfo.index + 1,
 			url:link
 		});
 	}

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
 	"name": "Outlook.com mailto",
-	"version": "2.1",
+	"version": "2.2",
 	"description": "Add Outlook.com as a default email provider for all mailto links.",
 	"author": "Wesley Branton",
 	


### PR DESCRIPTION
[FIXED] Opening link in new tab no longer creates additional blank tab
[FIXED] Created tab always appears next to the original tab